### PR TITLE
Use scope.get instead of scope.attr

### DIFF
--- a/can-view-import.js
+++ b/can-view-import.js
@@ -1,6 +1,5 @@
 var assign = require('can-util/js/assign/assign');
 var canData = require('can-util/dom/data/data');
-var isFunction = require('can-util/js/is-function/is-function');
 var importer = require('can-util/js/import/import');
 
 var nodeLists = require('can-view-nodelist');
@@ -11,7 +10,7 @@ tag("can-import", function(el, tagData){
 	var moduleName = el.getAttribute("from");
 	// If the module is part of the helpers pass that into can.import
 	// as the parentName
-	var templateModule = tagData.options.attr("helpers.module");
+	var templateModule = tagData.options.get("helpers.module");
 	var parentName = templateModule ? templateModule.id : undefined;
 
 	if(!moduleName) {
@@ -19,11 +18,6 @@ tag("can-import", function(el, tagData){
 	}
 
 	var importPromise = importer(moduleName, parentName);
-	var root = tagData.scope.attr("%root");
-
-	if(root && isFunction(root.waitFor)) {
-		root.waitFor(importPromise);
-	}
 
 	// Set the viewModel to the promise
 	canData.set.call(el, "viewModel", importPromise);

--- a/can-view-import_test.js
+++ b/can-view-import_test.js
@@ -118,15 +118,16 @@ if(window.steal) {
 			"<content></content>" +
 			"{{else}}" +
 			"<div class='loading'></div>" +
-			"{{/isResolved}}")
+			"{{/isResolved}}"),
+			leakScope: true
 		});
 
-		var template = "<can-import from='can-view-import/test/other.stache!' {^@value}='*other' can-tag='my-waiter'>{{{*other()}}}</can-import>";
+		var template = "<can-import from='can-view-import/test/other.stache' {^@value}='*other' can-tag='my-waiter'>{{{*other()}}}</can-import>";
 
 		stache.async(template).then(function(renderer){
 			var frag = renderer(new CanMap());
 
-			importer("can-view-import/test/other.stache!").then(function(){
+			importer("can-view-import/test/other.stache").then(function(){
 				ok(frag.childNodes[0].childNodes.length > 1, "Something besides a text node is inserted");
 				equal(frag.childNodes[0].childNodes[2].firstChild.nodeValue, "hi there", "Partial worked with can-tag");
 


### PR DESCRIPTION
This removes the use of a deprecated can-view-scope API.

Closes #4

Also removes the use of `%root` since that is not supported in 3.0.