### PR TITLE
chore(package): update can-event to version 3.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "main": "can-view-import",
   "keywords": [],
   "dependencies": {
-    "can-event": "^3.5.0-pre.2",
+    "can-event": "^3.6.0",
     "can-util": "^3.9.5",
     "can-view-callbacks": "^3.1.0-pre.0",
     "can-view-nodelist": "^3.1.0-pre.0",


### PR DESCRIPTION
Closes #37 