### PR TITLE
can-dynamic-import tag support

### DIFF
--- a/can-view-import.js
+++ b/can-view-import.js
@@ -8,8 +8,6 @@ var nodeLists = require('can-view-nodelist');
 var tag = require('can-view-callbacks').tag;
 var events = require('can-event');
 var canLog = require("can-util/js/log/log");
-var canMakeArray = require("can-util/js/make-array/make-array");
-
 
 function processImport(el, tagData) {
 
@@ -50,26 +48,9 @@ function processImport(el, tagData) {
 	}
 	// Render the subtemplate and register nodeLists
 	else {
-		var frag; 
-
-		if(tagData.subtemplate) { 
-			frag = tagData.subtemplate(scope, tagData.options);
-		}
-		if(frag && this.tagName === "can-import") {
-			var childNodes = canMakeArray(frag.childNodes);
-		  for(var i = 0; i < childNodes.length; i++) {
-				if(
-					childNodes[i].nodeType === 1 ||
-					childNodes[i].nodeType === 3 && childNodes[i].textContent.trim().length < 0
-				) {
-					frag = null;
-					break;
-				}
-			}
-		}
-		if(!frag) {
-			frag = DOCUMENT().createDocumentFragment();
-		}
+		var frag = tagData.subtemplate ?
+			tagData.subtemplate(scope, tagData.options) :
+			DOCUMENT().createDocumentFragment();
 
 		var nodeList = nodeLists.register([], undefined, tagData.parentNodeList || true);
 		nodeList.expression = "<" + this.tagName + ">";
@@ -83,5 +64,6 @@ function processImport(el, tagData) {
 	}
 }
 
-tag("can-import", processImport.bind({ tagName: "can-import" }));
-tag("can-dynamic-import", processImport.bind({ tagName: "can-dynamic-import" }));
+["can-import", "can-dynamic-import"].forEach(function(tagName) {
+	tag(tagName, processImport.bind({ tagName: tagName }));
+});

--- a/can-view-import_test.js
+++ b/can-view-import_test.js
@@ -145,8 +145,38 @@ if(window.steal) {
 	}
 
 	if (!System.isEnv('production')) {
-		asyncTest("can dynamically import a template and use it", function(){
+		asyncTest("can dynamically import a template with can-import and use it", function(){
 			var template = "<can-import from='can-view-import/test/other-dynamic.stache!' {^@value}='*other'/>{{> *other}}";
+
+			stache.async(template).then(function(renderer){
+				var frag = renderer();
+
+				// Import will happen async
+				importer("can-view-import/test/other.stache!").then(function(){
+					equal(frag.childNodes[3].firstChild.nodeValue, "hi there", "Partial was renderered right after the can-import");
+
+					QUnit.start();
+				});
+			});
+
+		});
+		asyncTest("can dynamically import a template with can-dynamic-import (self-closing) and use it", function(){
+			var template = "<can-import from='can-view-import/test/other-dynamic-unary.stache!' {^@value}='*other'/>{{> *other}}";
+
+			stache.async(template).then(function(renderer){
+				var frag = renderer();
+
+				// Import will happen async
+				importer("can-view-import/test/other.stache!").then(function(){
+					equal(frag.childNodes[3].firstChild.nodeValue, "hi there", "Partial was renderered right after the can-import");
+
+					QUnit.start();
+				});
+			});
+
+		});
+		asyncTest("can dynamically import a template with can-dynamic-import and use it", function(){
+			var template = "<can-import from='can-view-import/test/other-dynamic-block.stache!' {^@value}='*other'/>{{> *other}}";
 
 			stache.async(template).then(function(renderer){
 				var frag = renderer();
@@ -164,7 +194,7 @@ if(window.steal) {
 
 	if(!System.isEnv("production") && typeof console === "object") {
 		asyncTest("loading errors are logged to the console", function(){
-			var template = "<can-import from='can-view-import/test/error'></can-import>";
+			var template = "<can-import from='can-view-import/test/error'>{{foo}}</can-import>";
 
 			var error = console.error;
 			console.error = function(type){

--- a/package.json
+++ b/package.json
@@ -31,8 +31,8 @@
     "can-event": "^3.6.0",
     "can-util": "^3.9.5",
     "can-view-callbacks": "^3.2.0",
-    "can-view-nodelist": "^3.1.0-pre.0",
-    "steal-stache": "^3.1.0-pre.0"
+    "can-view-nodelist": "^3.1.0",
+    "steal-stache": "^3.1.0"
   },
   "devDependencies": {
     "bit-docs": "0.0.7",

--- a/test/other-dynamic-block.stache
+++ b/test/other-dynamic-block.stache
@@ -1,0 +1,5 @@
+<can-dynamic-import from="can-view-import/test/thing">
+
+</can-dynamic-import>
+
+<span>hi there</span>

--- a/test/other-dynamic-unary.stache
+++ b/test/other-dynamic-unary.stache
@@ -1,0 +1,3 @@
+<can-dynamic-import from="can-view-import/test/thing" />
+
+<span>hi there</span>


### PR DESCRIPTION
Fixes #9 when https://github.com/canjs/can-stache/pull/309 is also merged and released.  See said PR for more about what can-dynamic-import does.

Tests were added in this repo, including a fix for the error case test to make the import dynamic under the new rules.

(Note: do not merge until the new can-stache release can be referenced in package.json)