### PR TITLE
Fixing dynamic imports (try 2)

### DIFF
--- a/can-view-import.js
+++ b/can-view-import.js
@@ -8,8 +8,6 @@ var nodeLists = require('can-view-nodelist');
 var tag = require('can-view-callbacks').tag;
 var events = require('can-event');
 var canLog = require("can-util/js/log/log");
-var canMakeArray = require("can-util/js/make-array/make-array");
-
 
 function processImport(el, tagData) {
 
@@ -50,26 +48,9 @@ function processImport(el, tagData) {
 	}
 	// Render the subtemplate and register nodeLists
 	else {
-		var frag; 
-
-		if(tagData.subtemplate) { 
-			frag = tagData.subtemplate(scope, tagData.options);
-		}
-		if(frag && this.tagName === "can-import") {
-			var childNodes = canMakeArray(frag.childNodes);
-		  for(var i = 0; i < childNodes.length; i++) {
-				if(
-					childNodes[i].nodeType === 1 ||
-					childNodes[i].nodeType === 3 && childNodes[i].textContent.trim().length < 0
-				) {
-					frag = null;
-					break;
-				}
-			}
-		}
-		if(!frag) {
-			frag = DOCUMENT().createDocumentFragment();
-		}
+		var frag = tagData.subtemplate ?
+			tagData.subtemplate(scope, tagData.options) :
+			DOCUMENT().createDocumentFragment();
 
 		var nodeList = nodeLists.register([], undefined, tagData.parentNodeList || true);
 		nodeList.expression = "<" + this.tagName + ">";
@@ -83,5 +64,6 @@ function processImport(el, tagData) {
 	}
 }
 
-tag("can-import", processImport.bind({ tagName: "can-import" }));
-tag("can-dynamic-import", processImport.bind({ tagName: "can-dynamic-import" }));
+["can-import", "can-dynamic-import"].forEach(function(tagName) {
+	tag(tagName, processImport.bind({ tagName: tagName }));
+});

--- a/can-view-import_test.js
+++ b/can-view-import_test.js
@@ -145,8 +145,38 @@ if(window.steal) {
 	}
 
 	if (!System.isEnv('production')) {
-		asyncTest("can dynamically import a template and use it", function(){
+		asyncTest("can dynamically import a template with can-import and use it", function(){
 			var template = "<can-import from='can-view-import/test/other-dynamic.stache!' {^@value}='*other'/>{{> *other}}";
+
+			stache.async(template).then(function(renderer){
+				var frag = renderer();
+
+				// Import will happen async
+				importer("can-view-import/test/other.stache!").then(function(){
+					equal(frag.childNodes[3].firstChild.nodeValue, "hi there", "Partial was renderered right after the can-import");
+
+					QUnit.start();
+				});
+			});
+
+		});
+		asyncTest("can dynamically import a template with can-dynamic-import (self-closing) and use it", function(){
+			var template = "<can-import from='can-view-import/test/other-dynamic-unary.stache!' {^@value}='*other'/>{{> *other}}";
+
+			stache.async(template).then(function(renderer){
+				var frag = renderer();
+
+				// Import will happen async
+				importer("can-view-import/test/other.stache!").then(function(){
+					equal(frag.childNodes[3].firstChild.nodeValue, "hi there", "Partial was renderered right after the can-import");
+
+					QUnit.start();
+				});
+			});
+
+		});
+		asyncTest("can dynamically import a template with can-dynamic-import and use it", function(){
+			var template = "<can-import from='can-view-import/test/other-dynamic-block.stache!' {^@value}='*other'/>{{> *other}}";
 
 			stache.async(template).then(function(renderer){
 				var frag = renderer();
@@ -164,7 +194,7 @@ if(window.steal) {
 
 	if(!System.isEnv("production") && typeof console === "object") {
 		asyncTest("loading errors are logged to the console", function(){
-			var template = "<can-import from='can-view-import/test/error'></can-import>";
+			var template = "<can-import from='can-view-import/test/error'>{{foo}}</can-import>";
 
 			var error = console.error;
 			console.error = function(type){

--- a/docs/can-view-import.md
+++ b/docs/can-view-import.md
@@ -29,6 +29,52 @@ Dynamically import *MODULE_NAME*; the scope within the template is a [Promise](h
 
 @param {moduleName} [MODULE_NAME] A module that this template depends on.
 
+@signature `<can-dynamic-import from="MODULE_NAME" value:to="*MODULE_REF"/>`
+
+Dynamically import a module from within a [can-stache] template. Since there is no subtemplate to attach the [Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) to as the current scope, you must export the Promise's resolved value to the template's refs scope using [can-view-import.value].
+
+```
+<can-dynamic-import from="components/tabs" value:to="*tabsWidget" />
+{{#if *tabsWidget}}
+	<tabs-widget />
+{{/if}}
+
+{{! other can-reflect-promise keys also work, as does the *REFERENCE shorthand from can-stache-bindings }}
+
+<can-dynamic-import from="components/tabs" 
+	isPending:to="*tabsWidgetPending"
+	isRejected:to="*tabsWidgetError"
+	*tabs-widget-promise />
+{{#if *tabsWidgetPending}}
+	Loading...
+{{else}}
+	<tabs-widget />
+	{{#if *tabsWidgetError}}
+		{{*tabsWidgetPromise.reason}}
+	{{/if}}
+{{/if}}
+
+```
+
+@param {moduleName} [MODULE_NAME] A module that this template depends on.
+
+
+@signature `<can-dynamic-import from="MODULE_NAME">content</can-import>`
+
+Dynamically import *MODULE_NAME*; the scope within the template is a [Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise).
+
+```
+<can-dynamic-import from="components/tabs">
+  {{#if isResolved}}
+    <tabs-widget />
+  {{/if}}
+</can-import>
+```
+
+@param {moduleName} [MODULE_NAME] A module that this template depends on.
+
+
+
 @body
 
 ## Use

--- a/docs/value.md
+++ b/docs/value.md
@@ -1,9 +1,9 @@
-@function can-view-import.value {^value}
+@function can-view-import.value value:to
 @parent can-view-import.attributes
 
 @description Set the value that is returned from the [can-view-import can-import] Promise to a [can-stache-bindings.reference reference scope] variable.
 
-@signature `{^value}="*NAME"`
+@signature `value:to="*NAME"`
 
 Sets up a [can-stache-bindings.toParent] binding to \*NAME in the references scope.
 

--- a/package.json
+++ b/package.json
@@ -31,8 +31,8 @@
     "can-event": "^3.6.0",
     "can-util": "^3.9.5",
     "can-view-callbacks": "^3.2.0",
-    "can-view-nodelist": "^3.1.0-pre.0",
-    "steal-stache": "^3.1.0-pre.0"
+    "can-view-nodelist": "^3.1.0",
+    "steal-stache": "^3.1.0"
   },
   "devDependencies": {
     "bit-docs": "0.0.7",

--- a/test/other-dynamic-block.stache
+++ b/test/other-dynamic-block.stache
@@ -1,0 +1,5 @@
+<can-dynamic-import from="can-view-import/test/thing">
+
+</can-dynamic-import>
+
+<span>hi there</span>

--- a/test/other-dynamic-unary.stache
+++ b/test/other-dynamic-unary.stache
@@ -1,0 +1,3 @@
+<can-dynamic-import from="can-view-import/test/thing" />
+
+<span>hi there</span>


### PR DESCRIPTION
Fixes #9 when https://github.com/canjs/can-stache/pull/309 is also merged and released.  See said PR for more about what can-dynamic-import does.

Tests were added in this repo, including a fix for the error case test to make the import dynamic under the new rules.

(Note: do not merge until the new can-stache release can be referenced in package.json)