### PR TITLE
Remove deprecated can-util methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ node_modules
 dist/
 doc/GREADME.md
 doc/docMap.json
+package-lock.json

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/can-view-import.js
+++ b/can-view-import.js
@@ -1,6 +1,6 @@
-var assign = require('can-util/js/assign/assign');
-var canData = require('can-util/dom/data/data');
-var DOCUMENT = require("can-util/dom/document/document");
+var assign = require('can-assign');
+var canData = require('can-dom-data-state');
+var DOCUMENT = require("can-globals/document/document");
 var getChildNodes = require('can-util/dom/child-nodes/child-nodes');
 var importer = require('can-util/js/import/import');
 var mutate = require("can-util/dom/mutate/mutate");
@@ -8,8 +8,8 @@ var nodeLists = require('can-view-nodelist');
 var viewCallbacks = require('can-view-callbacks');
 var tag = viewCallbacks.tag;
 var events = require('can-event');
-var canLog = require("can-util/js/log/log");
-var dev = require("can-util/js/dev/dev");
+var canLog = require("can-log/");
+var dev = require("can-log/dev/dev");
 
 function processImport(el, tagData) {
 

--- a/package.json
+++ b/package.json
@@ -24,17 +24,20 @@
     "release:minor": "npm version minor && npm publish",
     "release:major": "npm version major && npm publish",
     "build": "node build.js",
-    "detect-cycle": "detect-cyclic-packages --ignore done-serve"
+    "detect-cycle": "detect-cyclic-packages --ignore done-serve,steal-stache"
   },
   "main": "can-view-import",
   "keywords": [],
   "dependencies": {
+    "can-assign": "^1.0.0",
+    "can-dom-data-state": "^0.1.1",
     "can-event": "^3.6.0",
+    "can-globals": "^0.2.3",
+    "can-log": "^0.1.0",
     "can-stache": "^3.7.3",
     "can-util": "^3.9.5",
     "can-view-callbacks": "^3.2.0",
-    "can-view-nodelist": "^3.1.0",
-    "steal-stache": "^3.1.0"
+    "can-view-nodelist": "^3.1.0"
   },
   "devDependencies": {
     "bit-docs": "0.0.7",
@@ -47,6 +50,7 @@
     "jshint": "^2.9.1",
     "steal": "^1.2.0",
     "steal-qunit": "^1.0.0",
+    "steal-stache": "^3.1.0",
     "steal-tools": "^1.0.0",
     "testee": "^0.7.0"
   }


### PR DESCRIPTION
`can-util/js/dev/dev` in particular is causing `canjs`' tests to fail. This PR updates all deprecated methods of `can-util`.