### PR TITLE
Make the importPromise a notContext scope

### DIFF
--- a/can-view-import.js
+++ b/can-view-import.js
@@ -33,7 +33,7 @@ function processImport(el, tagData) {
 	canData.set.call(el, "scope", importPromise);
 
 	// Set the scope
-	var scope = tagData.scope.add(importPromise);
+	var scope = tagData.scope.add(importPromise, { notContext: true });
 
 	// If there is a can-tag present we will hand-off rendering to that tag.
 	var handOffTag = el.getAttribute("can-tag");

--- a/can-view-import_test.js
+++ b/can-view-import_test.js
@@ -155,8 +155,14 @@ if(window.steal) {
 
 			var template = "<can-import from='can-view-import/test/other.stache' @value:to='*other' can-tag='my-waiter'>{{{*other()}}}</can-import>";
 
+			var finishWarningCheck = testHelpers.dev.willWarn(/is not in the current scope/, function(message, matched) {
+				QUnit.notOk(matched, "importPromise throws a false-positive warning (#83)");
+			});
+
 			stache.async(template).then(function(renderer){
 				var frag = renderer(new CanMap());
+
+				finishWarningCheck();
 
 				importer("can-view-import/test/other.stache").then(function(){
 					ok(frag.childNodes[0].childNodes.length > 1, "Something besides a text node is inserted");


### PR DESCRIPTION
This fixes a false-positive “not in the current scope, so it is being read from the parent scope” warning.

Fixes https://github.com/canjs/can-view-import/issues/83