### PR TITLE
Properly pass parentNodeList to subtemplate

### DIFF
--- a/can-view-import.js
+++ b/can-view-import.js
@@ -64,12 +64,12 @@ function processImport(el, tagData) {
 	}
 	// Render the subtemplate and register nodeLists
 	else {
-		var frag = tagData.subtemplate ?
-			tagData.subtemplate(scope, tagData.options) :
-			DOCUMENT().createDocumentFragment();
-
-		var nodeList = nodeLists.register([], undefined, tagData.parentNodeList || true);
+		var nodeList = nodeLists.register([], undefined, tagData.parentNodeList || true, false);
 		nodeList.expression = "<" + this.tagName + ">";
+
+		var frag = tagData.subtemplate ?
+			tagData.subtemplate(scope, tagData.options, nodeList) :
+			DOCUMENT().createDocumentFragment();
 
 		var removalDisposal = domMutate.onNodeRemoval(el, function () {
 			if (!el.ownerDocument.contains(el)) {

--- a/can-view-import_test.js
+++ b/can-view-import_test.js
@@ -113,7 +113,7 @@ if(window.steal) {
 				return map.get("bar");
 			});
 
-			template({ foo, map });
+			template({ foo: foo, map: map });
 
 			importer("can-view-import/test/hello").then(function(){
 				// Get around temporary bind stuff
@@ -123,7 +123,7 @@ if(window.steal) {
 					map.set("bar", undefined);
 					queues.batch.stop();
 					start();
-				}, 100);;
+				}, 100);
 			});
 		});
 	}

--- a/package.json
+++ b/package.json
@@ -40,6 +40,8 @@
   "devDependencies": {
     "bit-docs": "0.0.7",
     "can-component": "^4.0.0-pre.25",
+    "can-observation": "4.0.0-pre.25",
+    "can-queues": "^0.5.0",
     "can-simple-map": "^4.0.0-pre.13",
     "can-simple-observable": "^2.0.0-pre.23",
     "can-stache": "^4.0.0-pre.48",


### PR DESCRIPTION
This fixes nodeLists, so that the parentNodeList is passed through to
children.

Fixes #87