### PR TITLE
handling documents that don't support .contains (for IE11)

### DIFF
--- a/can-view-import.js
+++ b/can-view-import.js
@@ -73,7 +73,9 @@ function processImport(el, tagData) {
 			DOCUMENT().createDocumentFragment();
 
 		var removalDisposal = domMutate.onNodeRemoval(el, function () {
-			if (!el.ownerDocument.contains(el)) {
+			var doc = el.ownerDocument;
+			var ownerNode = doc.contains ? doc : doc.documentElement;
+			if (!ownerNode || ownerNode.contains(el) === false) {
 				removalDisposal();
 				nodeLists.unregister(nodeList);
 			}

--- a/can-view-import_test.js
+++ b/can-view-import_test.js
@@ -6,6 +6,7 @@ var importer = require('can-import-module');
 var tag = require('can-view-callbacks').tag;
 var testHelpers = require('can-test-helpers');
 var SimpleObservable = require("can-simple-observable");
+var DOCUMENT = require("can-globals/document/document");
 
 require('./can-view-import');
 
@@ -274,4 +275,24 @@ if(window.steal) {
 		});
 	}
 	*/
+
+	if (!System.isEnv('production')) {
+		asyncTest("cleaned up correctly when element is removed", function(){
+			var doc = DOCUMENT();
+			var fixture = doc.getElementById("qunit-fixture");
+			var template = "<can-import from='can-view-import/test/person' />";
+			var iai = getIntermediateAndImports(template);
+			var renderer = stache(iai.intermediate);
+			var res = renderer(new SimpleMap());
+			fixture.appendChild(res);
+
+			importer("can-view-import/test/person").then(function(){
+				var el = fixture.querySelector("can-import");
+				fixture.removeChild(el);
+				// testing that removalDisposal does not throw
+				QUnit.ok(true);
+				start();
+			});
+		});
+	}
 }


### PR DESCRIPTION
closes https://github.com/canjs/can-view-import/issues/114.